### PR TITLE
Suppress spurious space.

### DIFF
--- a/textmerg.dtx
+++ b/textmerg.dtx
@@ -601,7 +601,7 @@ horrid
       \ifx#1+\DontAllowBlank
       \else
          \ifx#1-\AllowBlank
-         \else\ReadIn#1
+         \else\ReadIn#1%
          \fi
       \fi
    \fi\NextParse}


### PR DESCRIPTION
See https://tex.stackexchange.com/questions/443059/preserve-label-spacing-dimensions-when-using-mailmerge

Not sure how this will affect backward-compatibility.